### PR TITLE
This commit adds a `display: block` to the `home` link to stop two fo…

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3674,12 +3674,13 @@ header[role="banner"] {
     header[role="banner"].au-header.au-header--hero.au-header--alt.au-header--dark {
       background-color: #313131; }
   header[role="banner"] a[rel="home"] {
-    border: none; }
+    border: none;
+    display: block;
+    margin-bottom: 40px;
+    margin-bottom: 2.5rem; }
     header[role="banner"] a[rel="home"]:focus {
       outline: 3px solid #9263DE; }
   header[role="banner"] img.site-logo {
-    margin-bottom: 40px;
-    margin-bottom: 2.5rem;
     max-width: 300px;
     max-width: 18.75rem;
     border: none; }

--- a/src/sass/header/_dta-gov-au.header.images.scss
+++ b/src/sass/header/_dta-gov-au.header.images.scss
@@ -1,12 +1,13 @@
 // Image styles for the header.
 a[rel="home"] {
   border: none;
+  display: block;
+  @include AU-space( margin-bottom, 2.5unit );
   &:focus {
     @include AU-outline;
   }
 }
 img.site-logo {
-  @include AU-space( margin-bottom, 2.5unit );
   @include AU-space( max-width, 18.75unit );
   border: none;
 }


### PR DESCRIPTION
…cus outlines appearing. It also shifts the margin from the image to the link, to prevent a large empty gap appearing in the focus outline.