### PR TITLE
This commit:

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3744,13 +3744,11 @@ main[role="main"].page-content {
     margin-bottom: 1rem; }
   main[role="main"].page-content .au-introduction {
     margin-bottom: 32px;
-    margin-bottom: 2rem; }
-    main[role="main"].page-content .au-introduction p {
-      font-size: 24px;
-      font-size: 1.5rem;
-      line-height: 1.5;
-      color: #636363;
-      max-width: 42em; }
+    margin-bottom: 2rem;
+    font-size: 24px;
+    font-size: 1.5rem;
+    line-height: 1.5;
+    color: #636363; }
   main[role="main"].page-content .au-hero img {
     margin-bottom: 16px;
     margin-bottom: 1rem; }

--- a/src/sass/content/_dta-gov-au.content.introduction.scss
+++ b/src/sass/content/_dta-gov-au.content.introduction.scss
@@ -2,9 +2,6 @@
 
 .au-introduction {
   @include AU-space( margin-bottom, 2unit );
-  p {
-    @include AU-fontgrid( lg );
-    color: $AU-color-foreground-muted-suggestion;
-    max-width: $AU-maxwidth;
-  }
+  @include AU-fontgrid( lg );
+  color: $AU-color-foreground-muted-suggestion;
 }

--- a/templates/block/block--page-title-block.html.twig
+++ b/templates/block/block--page-title-block.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * Removed extra junk around the output; this is, after all, just the page title.
+ */
+#}
+
+{% block content %}
+  {{ content }}
+{% endblock %}

--- a/templates/block/block--system-main-block.html.twig
+++ b/templates/block/block--system-main-block.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * Removed the wrapper <div> from the main content area.
+ */
+#}
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}

--- a/templates/field/field--node--title.html.twig
+++ b/templates/field/field--node--title.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Theme override for the node title field.
+ *
+ * This is an override of field.html.twig for the node title field. See that
+ * template for documentation about its details and overrides.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing span element.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see field.html.twig
+ * 
+ * Removed <span> tags from around the output.
+ */
+#}
+  {%- for item in items -%}
+    {{ item.content }}
+  {%- endfor -%}


### PR DESCRIPTION
- Updates the `.au-introduction` class to make it simpler and apply to a `<p>` tag.
- Removes wrapper guff from around the page title and the body content blocks.