### PR TITLE
Back to top update

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3222,6 +3222,19 @@ blockquote {
     content: '⇗';
     color: #ffffff; }
 
+#back-to-top {
+  margin: 32px 0px 16px 0px;
+  margin: 2rem 0rem 1rem 0rem;
+  text-align: center; }
+  #back-to-top a {
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #007099; }
+    #back-to-top a:after {
+      content: '\02191';
+      background-image: none; }
+
 body {
   margin: 0; }
   body .layout-container {
@@ -3604,27 +3617,6 @@ body {
         margin-bottom: 16px;
         margin-bottom: 1rem;
         color: #636363; }
-
-.page-front #back-to-top {
-  margin-bottom: 48px;
-  margin-bottom: 3rem;
-  text-align: center; }
-  @media (min-width: 768px) {
-    .page-front #back-to-top {
-      margin-bottom: 40px;
-      margin-bottom: 2.5rem; } }
-  @media (min-width: 992px) {
-    .page-front #back-to-top {
-      margin-bottom: 80px;
-      margin-bottom: 5rem; } }
-  .page-front #back-to-top a {
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.5;
-    color: #007099; }
-    .page-front #back-to-top a:after {
-      content: '\02191';
-      background-image: none; }
 
 header[role="banner"] {
   border-bottom: 8px solid #45C2F0;

--- a/src/sass/base/_dta-gov-au.base.back-to-top.scss
+++ b/src/sass/base/_dta-gov-au.base.back-to-top.scss
@@ -1,13 +1,7 @@
 // Styles for back to top link on the home page.
 
 #back-to-top {
-  @include AU-space( margin-bottom, 3unit );
-  @include AU-media( sm ) {
-    @include AU-space( margin-bottom, 2.5unit );
-  }
-  @include AU-media( md ) {
-    @include AU-space( margin-bottom, 5unit );
-  }
+  @include AU-space( margin, 2unit 0unit 1unit 0unit );
   text-align: center;
   a {
     @include AU-fontgrid( sm );

--- a/src/sass/base/_dta-gov-au.base.scss
+++ b/src/sass/base/_dta-gov-au.base.scss
@@ -12,3 +12,4 @@
 @import "dta-gov-au.base.responsive-menu";
 @import "dta-gov-au.base.pullquote.scss";
 @import "dta-gov-au.base.au";
+@import 'dta-gov-au.base.back-to-top';

--- a/src/sass/home/_dta-gov-au.home.scss
+++ b/src/sass/home/_dta-gov-au.home.scss
@@ -6,5 +6,4 @@
   @import 'dta-gov-au.home.mid-top-content';
   @import 'dta-gov-au.home.mid-bottom-content';
   @import 'dta-gov-au.home.bottom-content';
-  @import 'dta-gov-au.home.back-to-top';
 }

--- a/templates/block/block--backtotop.html.twig
+++ b/templates/block/block--backtotop.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+
+ /**
+  * Updated to remove wrapper stuff which is provided by home.html.twig.
+  * Removed title, title_prefix and title_suffix. This will remove contextual links
+  * which mess with the display for authors.
+#}
+<div id="back-to-top">
+  <div class="container">
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+</div>

--- a/templates/includes/home.html.twig
+++ b/templates/includes/home.html.twig
@@ -89,9 +89,5 @@
   </div>
 </div>
 <div class="row">
-  <div id="back-to-top">
-    <div class="container">
-      <a class="au-direction-link au-direction-link--up" href="#top">Back to top</a>
-    </div>
-  </div>
+  {{ drupal_block('backtotop') }}
 </div>

--- a/templates/layout/page--error.html.twig
+++ b/templates/layout/page--error.html.twig
@@ -73,10 +73,6 @@
   {% endif %}
   </main>
 
-  {% if page.footer %}
-    <footer role="contentinfo">
-      {% include '@dta_gov_au/includes/footer.html.twig' %}
-    </footer>
-  {% endif %}
+  {% include '@dta_gov_au/includes/footer.html.twig' %}
 
 </div>{# /.layout-container #}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -87,10 +87,6 @@
   {% endif %}
   </main>
 
-  {% if page.footer %}
-    <footer role="contentinfo">
-      {% include '@dta_gov_au/includes/footer.html.twig' %}
-    </footer>
-  {% endif %}
+  {% include '@dta_gov_au/includes/footer.html.twig' %}
 
 </div>{# /.layout-container #}


### PR DESCRIPTION
This commit:
- Moves the 'back-to-top' block out of the `home` set and into the `base` set.
- Removes responsive changes to back to top padding.
- A template file is included for the back-to-top block to maintain layout.
- Removes the hard coded back-to-top link from `home.html.twig`.

Also removes doubled `<footer>` tags at the bottom of `page.html.twig` and `page--error.html.twig`.