### PR TITLE
Spacing on search page

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3612,6 +3612,8 @@ main[role="main"].page-content {
     font-size: 2.5rem;
     line-height: 1.5;
     line-height: 1.25; }
+    main[role="main"].page-content h1 + div {
+      margin-top: 1.5rem; }
   main[role="main"].page-content nav.au-inpage-nav-links {
     margin: 48px 0;
     margin: 3rem 0;

--- a/src/sass/content/_dta-gov-au.content.heading.scss
+++ b/src/sass/content/_dta-gov-au.content.heading.scss
@@ -3,4 +3,7 @@
 h1 {
   @include AU-fontgrid( xxl );
   line-height: 1.25;
+  + div {
+    margin-top: 1.5rem;
+  }
 }

--- a/templates/search_api_page/search-api-page.html.twig
+++ b/templates/search_api_page/search-api-page.html.twig
@@ -1,4 +1,4 @@
-<div class="search-api-page-block-form-wrapper row col-xs-12">
+<div class="search-api-page-block-form-wrapper row">
   <div class="col-xs-12 col-sm-6">
     {{ form }}
   </div>


### PR DESCRIPTION
This commit fixes spacing on the search results page. It also adds a default `margin-top` to any `<div>` tag following a `<h1>`.