### PR TITLE
Image alignment update

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3119,13 +3119,17 @@ blockquote {
 
 img.align-left, p.align-left {
   float: left;
-  margin: 0 24px 16px 0;
-  margin: 0 1.5rem 1rem 0; }
+  margin-bottom: 16px;
+  margin-bottom: 1rem;
+  margin-right: 24px;
+  margin-right: 1.5rem; }
 
 img.align-right, p.align-right {
   float: right;
-  margin: 0 0 16px 24px;
-  margin: 0 0 1rem 1.5rem; }
+  margin-bottom: 16px;
+  margin-bottom: 1rem;
+  margin-left: 24px;
+  margin-left: 1.5rem; }
 
 body {
   margin: 0; }

--- a/src/sass/base/_dta-gov-au.base.images.scss
+++ b/src/sass/base/_dta-gov-au.base.images.scss
@@ -3,10 +3,12 @@
 img, p {
   &.align-left {
     float: left;
-    @include AU-space( margin, 0 1.5unit 1unit 0 );
+    @include AU-space( margin-bottom, 1unit );
+    @include AU-space( margin-right, 1.5unit );
   }
   &.align-right {
     float: right;
-    @include AU-space( margin, 0 0 1unit 1.5unit );
+    @include AU-space( margin-bottom, 1unit );
+    @include AU-space( margin-left, 1.5unit );
   }
 }


### PR DESCRIPTION
This commit updates the image alignment slightly to allow for more precise control of margins. The original version was overwriting the base `<p>` `margin-top`.