### PR TITLE
Minor roadmap style updates

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3418,6 +3418,9 @@ img.align-right, p.align-right {
     font-size: 40px;
     font-size: 2.5rem;
     line-height: 1.5; }
+  .business-roadmap .view-grouping > div.row div.row > div, .business-roadmap .view-grouping > div.au-card-list div.row > div, .business-roadmap .view-grouping > div.row div.au-card-list > div, .business-roadmap .view-grouping > div.au-card-list div.au-card-list > div {
+    margin-left: -12px;
+    margin-left: -0.75rem; }
   .business-roadmap .view-grouping .skip-link-wrapper {
     display: block;
     position: absolute;
@@ -3524,8 +3527,8 @@ img.align-right, p.align-right {
     border-radius: 4px;
     border-radius: 0.25rem; }
     .business-roadmap .view-grouping .au-card--roadmap .au-card--roadmap__text {
-      padding: 16px 16px 24px 16px;
-      padding: 1rem 1rem 1.5rem 1rem;
+      padding: 16px 16px 40px 16px;
+      padding: 1rem 1rem 2.5rem 1rem;
       border-left: 8px solid;
       border-bottom: 1px solid #7F7F7F;
       border-bottom-left-radius: 4px;
@@ -3545,13 +3548,20 @@ img.align-right, p.align-right {
       @media (min-width: 768px) {
         .business-roadmap .view-grouping .au-card--roadmap .au-accordion {
           border: none; } }
+      .business-roadmap .view-grouping .au-card--roadmap .au-accordion .au-accordion__title:hover:after {
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-36 -48 208 208'%3E%3Cpath fill='%23313131' d='M64 0l64 64-16 16-64-64'/%3E%3Cpath fill='%23313131' d='M64 0l16 16-64 64L0 64'/%3E%3C/svg%3E"); }
       .business-roadmap .view-grouping .au-card--roadmap .au-accordion .au-accordion__title:after {
         position: absolute;
         top: auto;
-        margin-top: -24px;
-        margin-top: -1.5rem;
-        right: 32px;
-        right: 2rem; }
+        margin-top: -40px;
+        margin-top: -2.5rem;
+        right: 24px;
+        right: 1.5rem;
+        width: 32px;
+        width: 2rem;
+        height: 32px;
+        height: 2rem;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-36 -48 208 208'%3E%3Cpath fill='%23007099' d='M64 0l64 64-16 16-64-64'/%3E%3Cpath fill='%23007099' d='M64 0l16 16-64 64L0 64'/%3E%3C/svg%3E"); }
       .business-roadmap .view-grouping .au-card--roadmap .au-accordion .au-accordion__body-wrapper {
         columns: 1; }
       .business-roadmap .view-grouping .au-card--roadmap .au-accordion .au-accordion__body {

--- a/js/roadmap.js
+++ b/js/roadmap.js
@@ -5,7 +5,7 @@
   //   attach: function( context, settings ) {
   //
   //     var $grid = $('.business-roadmap .masonry-wrapper');
-  // 
+  //
   //     $($grid, context)
   //       .addClass('processed')
   //       .once('dtagovauRoadmapMasonry')
@@ -203,34 +203,52 @@
 
             backTo( $node, year, separate );
           }
-
-          $( '.skip-link-wrapper a.au-direction-link' ).on('click', function(event) {
-            var speed = 500;
-            var href = $(this).attr("href").split('#')[1];
-            if (href) {
-
-              // Use the 'once' library for AJAX calls.
-              $(this, context).once('behaviours').addClass('processed');
-
-              var element = '#' + href;
-              var position = $(element).offset().top;
-
-              // Setting 'tabindex' to -1 takes an element out of normal
-              // tab flow but allows it to be focused via javascript
-              $(element).attr('tabindex', -1).on('blur focusout', function() {
-
-                // When focus leaves this element,
-                // remove the tabindex attribute
-                $(element).removeAttr('tabindex');
-              }).focus(); // Focus on the content container
-
-              // Scroll the viewport to the destination.
-              $('html, body').animate({ scrollTop: position }, speed, "swing");
-              event.preventDefault();
-            }
-          });
         });
 
+    }
+  }
+  Drupal.behaviors.dtagovauRoadmapSmoothScroll = {
+    // We need to add the smooth scroll in again because Drupal by necessity
+    // loads this library after the main library.
+    attach: function( context, settings ) {
+      $( '.skip-link-wrapper a.au-direction-link', context )
+        .once('dtagovauRoadmapSmoothScroll')
+        .on('click', function(event) {
+
+          event.preventDefault();
+
+          var speed = 500,
+              path = $(this).attr("href").split('#')[0],
+              $element = $('#' + $(this).attr("href").split('#')[1]);
+
+          // Get rid of http:// or https:// from the start of the string.
+          if ( path.indexOf( '://' ) > -1 ) {
+            path = path.substring( path.indexOf( '://' ) + 3 );
+          }
+
+          // Knock off the domain.
+          if ( path.indexOf( '/' ) > -1 ) {
+            path = path.substring( path.indexOf( '/' ) );
+          }
+
+          if ($element.length > 0 && (!path || path == window.location.pathname)) {
+            var position = $element.offset().top;
+
+            // Scroll the viewport to the destination.
+            $('html, body').animate({
+              scrollTop: position
+            }, speed, "swing", function() {
+              // Setting 'tabindex' to -1 takes an element out of normal tab
+              // flow but allows it to be focused via JavaScript. We only do
+              // this when the animation is complete.
+              $element.attr('tabindex', -1).on('blur focusout', function() {
+
+                // When focus leaves this element, remove the tabindex attribute.
+                $element.removeAttr('tabindex');
+              }).focus(); // Focus on the content container
+            });
+        }
+      });
     }
   }
 })(jQuery, Drupal);

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -10,30 +10,43 @@
   Drupal.behaviors.dtagovauSmoothScroll = {
     // This creates a smooth scroll effect for on page links. It also moves the
     // focus correctly for keyboard uses as per https://www.bignerdranch.com/blog/web-accessibility-skip-navigation-links/.
-    attach: function(context, settings) {
-      $('a:not(.js-au-accordion)', context).once('smoothScroll').click(function(event) {
-        var speed = 500;
-        var href = $(this).attr("href").split('#')[1];
-        if (href) {
+    attach: function( context, settings ) {
+      $( '.skip-link-wrapper a.au-direction-link', context )
+        .once('dtagovauSmoothScroll')
+        .on('click', function(event) {
 
-          // Use the 'once' library for AJAX calls.
-          $(this, context).once('behaviours').addClass('processed');
-
-          var element = '#' + href;
-          var position = $(element).offset().top;
-
-          // Setting 'tabindex' to -1 takes an element out of normal
-          // tab flow but allows it to be focused via javascript
-          $(element).attr('tabindex', -1).on('blur focusout', function() {
-
-            // When focus leaves this element,
-            // remove the tabindex attribute
-            $(element).removeAttr('tabindex');
-          }).focus(); // Focus on the content container
-
-          // Scroll the viewport to the destination.
-          $('html, body').animate({ scrollTop: position }, speed, "swing");
           event.preventDefault();
+
+          var speed = 500,
+              path = $(this).attr("href").split('#')[0],
+              $element = $('#' + $(this).attr("href").split('#')[1]);
+
+          // Get rid of http:// or https:// from the start of the string.
+          if ( path.indexOf( '://' ) > -1 ) {
+            path = path.substring( path.indexOf( '://' ) + 3 );
+          }
+
+          // Knock off the domain.
+          if ( path.indexOf( '/' ) > -1 ) {
+            path = path.substring( path.indexOf( '/' ) );
+          }
+
+          if ($element.length > 0 && (!path || path == window.location.pathname)) {
+            var position = $element.offset().top;
+
+            // Scroll the viewport to the destination.
+            $('html, body').animate({
+              scrollTop: position
+            }, speed, "swing", function() {
+              // Setting 'tabindex' to -1 takes an element out of normal tab
+              // flow but allows it to be focused via JavaScript. We only do
+              // this when the animation is complete.
+              $element.attr('tabindex', -1).on('blur focusout', function() {
+
+                // When focus leaves this element, remove the tabindex attribute.
+                $element.removeAttr('tabindex');
+              }).focus(); // Focus on the content container
+            });
         }
       });
     }

--- a/src/sass/base/_dta-gov-au.base.roadmap.scss
+++ b/src/sass/base/_dta-gov-au.base.roadmap.scss
@@ -229,6 +229,9 @@
     h2 {
       @include AU-fontgrid( xxl );
     }
+    > div.row div.row > div {
+      @include AU-space( margin-left, -0.75unit );
+    }
     .skip-link-wrapper {
       display: block;
       position: absolute;
@@ -319,7 +322,7 @@
       border: 1px solid $AU-color-foreground-border-suggestion;
       @include AU-space( border-radius, 0.25unit );
       .au-card--roadmap__text {
-        @include AU-space( padding, 1unit 1unit 1.5unit 1unit );
+        @include AU-space( padding, 1unit 1unit 2.5unit 1unit );
         border-left: 8px solid;
         border-bottom: 1px solid $AU-color-foreground-border-suggestion;
         @include AU-space( border-bottom-left-radius, 0.25unit );
@@ -341,11 +344,27 @@
         @include AU-space( padding, 0unit );
         border: 1px solid $AU-color-foreground-border-suggestion;
         background-color: $AU-color-background-shade-suggestion;
-        .au-accordion__title:after {
-          position: absolute;
-          top: auto;
-          @include AU-space( margin-top, -1.5unit ); // Reposition the arrow at the top of the container.
-          @include AU-space( right, 2unit );
+        .au-accordion__title {
+          &:hover:after {
+            // We have to change the viewBox for the background images to increase the 'hitbox' for the accordion button.
+            background-image: AU-svguri(
+              "<svg xmlns='http://www.w3.org/2000/svg' viewBox='-36 -48 208 208'>" +
+                "<path fill='#{ $AU-color-foreground-text }' d='M64 0l64 64-16 16-64-64'/>" +
+                "<path fill='#{ $AU-color-foreground-text }' d='M64 0l16 16-64 64L0 64'/>" +
+              "</svg>");
+          }
+          &:after {
+            position: absolute;
+            top: auto;
+            @include AU-space( margin-top, -2.5unit ); // Reposition the arrow at the top of the container.
+            @include AU-space( right, 1.5unit );
+            @include AU-space( width, 2unit );
+            @include AU-space( height, 2unit );
+            background-image: AU-svguri(
+              "<svg xmlns='http://www.w3.org/2000/svg' viewBox='-36 -48 208 208'>" +
+                "<path fill='#{ $AU-color-foreground-action }' d='M64 0l64 64-16 16-64-64'/>" +
+                "<path fill='#{ $AU-color-foreground-action }' d='M64 0l16 16-64 64L0 64'/>" +
+              "</svg>");          }
         }
         .au-accordion__body-wrapper {
           columns: 1;

--- a/templates/views/views-view-unformatted--business-roadmap-page-taxonomy.html.twig
+++ b/templates/views/views-view-unformatted--business-roadmap-page-taxonomy.html.twig
@@ -27,7 +27,6 @@
   {% if title %}
       {{ title }}
     {% endif %}
-    <div class="masonry-wrapper">
     {% for row in rows %}
       {%
         set row_classes = [
@@ -36,6 +35,5 @@
       %}
         {{ row.content }}
     {% endfor %}
-    </div>
   </div>
 </div>


### PR DESCRIPTION
This commit updates the roadmap style:
- Updates the 'SmoothScroll' function to prevent weird jumping around and to ensure only internal page links are affect.
- Removes extra padding on the left hand side of cards to line them up properly.
- Adds a slightly different background image for the accordion to increase the 'hitbox' of accordion links.
- Removes the 'masonry-wrapper' class and `<div>`.