### PR TITLE
Updated to base card style

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -2976,7 +2976,11 @@ a.au-card {
           min-height: 17rem; } }
       @supports (display: flex) {
         .au-card-list.au-card-list--matchheight li, .au-card-list.au-card-list--matchheight article {
-          display: flex; } }
+          display: flex;
+          flex: 1 0 100%; }
+          @media (min-width: 768px) {
+            .au-card-list.au-card-list--matchheight li, .au-card-list.au-card-list--matchheight article {
+              flex: 1 0 33%; } } }
     @media (min-width: 768px) {
       .au-card-list.au-card-list--matchheight .au-card {
         min-height: 272px;

--- a/src/sass/base/_dta-gov-au.base.card.scss
+++ b/src/sass/base/_dta-gov-au.base.card.scss
@@ -180,7 +180,14 @@ a.au-card {
 			}
 			@supports( display: flex ) {
 				display: flex;
+				flex: 1 0 100%;
+				@include AU-media( sm ) {
+					flex: 1 0 33%;
+				}
+				@include AU-media( md ) {
+				}
 			}
+
 		}
 		.au-card {
 			@include AU-media( sm ) {


### PR DESCRIPTION
This commit slightly updates the base card style to make the flex widths explicit. Safari wasn't handling the ambiguity very well.

'sadfari' was a typo, nothing else.