### PR TITLE
Card colours and hover states

### DIFF
--- a/css/dta-gov-au.styles.css
+++ b/css/dta-gov-au.styles.css
@@ -3085,7 +3085,11 @@ a.au-card {
   margin-top: 0;
   margin-bottom: 0; }
   .au-card-list .au-cta-link {
-    margin-top: 0; }
+    margin-top: 0;
+    -webkit-transition: background-color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out; }
+    .au-card-list .au-cta-link:hover, .au-card-list .au-cta-link:focus {
+      background-color: #e0e0e0; }
     .au-card-list .au-cta-link:after {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E");
       display: block;
@@ -3100,31 +3104,6 @@ a.au-card {
       right: 24px;
       right: 1.5rem;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E"); }
-  .au-card-list li a.au-cta-link {
-    border-top-width: 3px;
-    border-top-style: solid;
-    -webkit-transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
-    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out; }
-  .au-card-list li:nth-of-type(5n+1) a.au-cta-link {
-    border-top-color: #912B87; }
-    .au-card-list li:nth-of-type(5n+1) a.au-cta-link:hover {
-      background-color: #EDDDEC; }
-  .au-card-list li:nth-of-type(5n+2) a.au-cta-link {
-    border-top-color: #32A556; }
-    .au-card-list li:nth-of-type(5n+2) a.au-cta-link:hover {
-      background-color: #DEF0E4; }
-  .au-card-list li:nth-of-type(5n+3) a.au-cta-link {
-    border-top-color: #5F43AC; }
-    .au-card-list li:nth-of-type(5n+3) a.au-cta-link:hover {
-      background-color: #E8E4F3; }
-  .au-card-list li:nth-of-type(5n+4) a.au-cta-link {
-    border-top-color: #EE6523; }
-    .au-card-list li:nth-of-type(5n+4) a.au-cta-link:hover {
-      background-color: #FCE6DC; }
-  .au-card-list li:nth-of-type(5n+5) a.au-cta-link {
-    border-top-color: #C91978; }
-    .au-card-list li:nth-of-type(5n+5) a.au-cta-link:hover {
-      background-color: #F6DAE9; }
   .au-card-list li {
     list-style: none; }
   .au-body .au-card-list li {
@@ -3969,7 +3948,11 @@ body {
       margin-bottom: 80px;
       margin-bottom: 5rem; } }
   .page-front #top-content .au-card-list .au-cta-link {
-    margin-top: 0; }
+    margin-top: 0;
+    -webkit-transition: background-color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out; }
+    .page-front #top-content .au-card-list .au-cta-link:hover, .page-front #top-content .au-card-list .au-cta-link:focus {
+      background-color: #e0e0e0; }
     .page-front #top-content .au-card-list .au-cta-link:after {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E");
       display: block;
@@ -3991,23 +3974,23 @@ body {
     transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out; }
   .page-front #top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link {
     border-top-color: #912B87; }
-    .page-front #top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link:hover {
+    .page-front #top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link:hover, .page-front #top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link:focus {
       background-color: #EDDDEC; }
   .page-front #top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link {
     border-top-color: #32A556; }
-    .page-front #top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link:hover {
+    .page-front #top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link:hover, .page-front #top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link:focus {
       background-color: #DEF0E4; }
   .page-front #top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link {
     border-top-color: #5F43AC; }
-    .page-front #top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link:hover {
+    .page-front #top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link:hover, .page-front #top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link:focus {
       background-color: #E8E4F3; }
   .page-front #top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link {
     border-top-color: #EE6523; }
-    .page-front #top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link:hover {
+    .page-front #top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link:hover, .page-front #top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link:focus {
       background-color: #FCE6DC; }
   .page-front #top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link {
     border-top-color: #C91978; }
-    .page-front #top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link:hover {
+    .page-front #top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link:hover, .page-front #top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link:focus {
       background-color: #F6DAE9; }
   .page-front #top-content h2 {
     font-weight: normal;
@@ -4050,7 +4033,11 @@ body {
       padding-bottom: 80px;
       padding-bottom: 5rem; } }
   .page-front #mid-top-content .au-card-list .au-cta-link {
-    margin-top: 0; }
+    margin-top: 0;
+    -webkit-transition: background-color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out; }
+    .page-front #mid-top-content .au-card-list .au-cta-link:hover, .page-front #mid-top-content .au-card-list .au-cta-link:focus {
+      background-color: #e0e0e0; }
     .page-front #mid-top-content .au-card-list .au-cta-link:after {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E");
       display: block;
@@ -4065,6 +4052,31 @@ body {
       right: 24px;
       right: 1.5rem;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E"); }
+  .page-front #mid-top-content .au-card-list li a.au-cta-link {
+    border-top-width: 3px;
+    border-top-style: solid;
+    -webkit-transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out; }
+  .page-front #mid-top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link {
+    border-top-color: #912B87; }
+    .page-front #mid-top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link:hover, .page-front #mid-top-content .au-card-list li:nth-of-type(5n+1) a.au-cta-link:focus {
+      background-color: #EDDDEC; }
+  .page-front #mid-top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link {
+    border-top-color: #32A556; }
+    .page-front #mid-top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link:hover, .page-front #mid-top-content .au-card-list li:nth-of-type(5n+2) a.au-cta-link:focus {
+      background-color: #DEF0E4; }
+  .page-front #mid-top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link {
+    border-top-color: #5F43AC; }
+    .page-front #mid-top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link:hover, .page-front #mid-top-content .au-card-list li:nth-of-type(5n+3) a.au-cta-link:focus {
+      background-color: #E8E4F3; }
+  .page-front #mid-top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link {
+    border-top-color: #EE6523; }
+    .page-front #mid-top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link:hover, .page-front #mid-top-content .au-card-list li:nth-of-type(5n+4) a.au-cta-link:focus {
+      background-color: #FCE6DC; }
+  .page-front #mid-top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link {
+    border-top-color: #C91978; }
+    .page-front #mid-top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link:hover, .page-front #mid-top-content .au-card-list li:nth-of-type(5n+5) a.au-cta-link:focus {
+      background-color: #F6DAE9; }
   .page-front #mid-top-content .au-body {
     background-color: transparent; }
   .page-front #mid-top-content h2 {
@@ -4164,7 +4176,11 @@ body {
         margin-left: 0.5625rem;
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23007099' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23007099' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E"); }
   .page-front #bottom-content .au-card-list .au-cta-link {
-    margin-top: 0; }
+    margin-top: 0;
+    -webkit-transition: background-color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out; }
+    .page-front #bottom-content .au-card-list .au-cta-link:hover, .page-front #bottom-content .au-card-list .au-cta-link:focus {
+      background-color: #e0e0e0; }
     .page-front #bottom-content .au-card-list .au-cta-link:after {
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E");
       display: block;
@@ -4404,7 +4420,11 @@ main[role="main"].page-content {
     margin-top: 32px;
     margin-top: 2rem; }
     main[role="main"].page-content .au-cards--blogs-news .au-card-list .au-cta-link {
-      margin-top: 0; }
+      margin-top: 0;
+      -webkit-transition: background-color 0.3s ease-in-out;
+      transition: background-color 0.3s ease-in-out; }
+      main[role="main"].page-content .au-cards--blogs-news .au-card-list .au-cta-link:hover, main[role="main"].page-content .au-cards--blogs-news .au-card-list .au-cta-link:focus {
+        background-color: #e0e0e0; }
       main[role="main"].page-content .au-cards--blogs-news .au-card-list .au-cta-link:after {
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cpath fill='%23313131' d='M128 64l-64 64-16-16 64-64'/%3E%3Cpath fill='%23313131' d='M128 64l-16 16-64-64L64 0'/%3E%3C/svg%3E");
         display: block;
@@ -4540,6 +4560,31 @@ main[role="main"].page-content {
   main[role="main"].page-content #related-links-block h2 {
     margin-bottom: 24px;
     margin-bottom: 1.5rem; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li a.au-cta-link {
+    border-top-width: 3px;
+    border-top-style: solid;
+    -webkit-transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
+    transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+1) a.au-cta-link {
+    border-top-color: #912B87; }
+    main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+1) a.au-cta-link:hover, main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+1) a.au-cta-link:focus {
+      background-color: #EDDDEC; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+2) a.au-cta-link {
+    border-top-color: #32A556; }
+    main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+2) a.au-cta-link:hover, main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+2) a.au-cta-link:focus {
+      background-color: #DEF0E4; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+3) a.au-cta-link {
+    border-top-color: #5F43AC; }
+    main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+3) a.au-cta-link:hover, main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+3) a.au-cta-link:focus {
+      background-color: #E8E4F3; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+4) a.au-cta-link {
+    border-top-color: #EE6523; }
+    main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+4) a.au-cta-link:hover, main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+4) a.au-cta-link:focus {
+      background-color: #FCE6DC; }
+  main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+5) a.au-cta-link {
+    border-top-color: #C91978; }
+    main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+5) a.au-cta-link:hover, main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight li:nth-of-type(5n+5) a.au-cta-link:focus {
+      background-color: #F6DAE9; }
   main[role="main"].page-content .au-landing-page-level-2-cards .au-card-list.au-card-list--matchheight .au-card {
     min-height: 240px;
     min-height: 15rem; }

--- a/src/sass/base/_dta-gov-au.base.card.scss
+++ b/src/sass/base/_dta-gov-au.base.card.scss
@@ -152,7 +152,6 @@ a.au-card {
 	list-style: none;
 	padding: 0;
 	@include AU-card-cta-link($AU-color-foreground-text, $AU-color-foreground-text);
-  @include AU-card-colours;
 	@include AU-space( margin-top, 0 );
 	@include AU-space( margin-bottom, 0 );
 

--- a/src/sass/base/_dta-gov-au.mixin.card-cta-link.scss
+++ b/src/sass/base/_dta-gov-au.mixin.card-cta-link.scss
@@ -1,6 +1,10 @@
 @mixin AU-card-cta-link($color: $AU-color-foreground-border-suggestion, $color-hover: $color) {
   .au-cta-link {
     @include AU-space( margin-top, 0 );
+    transition: background-color 0.3s ease-in-out;
+    &:hover, &:focus {
+      background-color: $AU-color-background-alt-shade-suggestion;
+    }
     &:after {
       background-image: AU-svguri('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">' +
           '<path fill="#{ $color }" d="M128 64l-64 64-16-16 64-64"/>' +

--- a/src/sass/base/_dta-gov-au.mixin.cards-colours.scss
+++ b/src/sass/base/_dta-gov-au.mixin.cards-colours.scss
@@ -11,7 +11,7 @@
     &:nth-of-type(5n+1) {
       a.au-cta-link {
         border-top-color: $top-border-purple;
-        &:hover {
+        &:hover, &:focus {
           background-color: #EDDDEC;
         }
       }
@@ -20,7 +20,7 @@
     &:nth-of-type(5n+2) {
       a.au-cta-link {
         border-top-color: $top-border-green;
-        &:hover {
+        &:hover, &:focus {
           background-color: #DEF0E4;
         }
       }
@@ -29,7 +29,7 @@
     &:nth-of-type(5n+3) {
       a.au-cta-link {
         border-top-color: $top-border-dark-purple;
-        &:hover {
+        &:hover, &:focus {
           background-color: #E8E4F3;
         }
       }
@@ -38,7 +38,7 @@
     &:nth-of-type(5n+4) {
       a.au-cta-link {
         border-top-color: $top-border-orange;
-        &:hover {
+        &:hover, &:focus {
           background-color: #FCE6DC;
         }
       }
@@ -47,7 +47,7 @@
     &:nth-of-type(5n+5) {
       a.au-cta-link {
         border-top-color: $top-border-pink;
-        &:hover {
+        &:hover, &:focus {
           background-color: #F6DAE9;
         }
       }

--- a/src/sass/content/_dta-gov-au.content.landing-page-level-2-cards.scss
+++ b/src/sass/content/_dta-gov-au.content.landing-page-level-2-cards.scss
@@ -5,8 +5,11 @@
   }
 }
 .au-landing-page-level-2-cards {
-  .au-card-list.au-card-list--matchheight .au-card {
-    @include AU-space( min-height, 15unit );
+  .au-card-list.au-card-list--matchheight {
+    @include AU-card-colours;
+    .au-card {
+      @include AU-space( min-height, 15unit );
+    }
   }
   .au-card {
     @include AU-space( padding, 1unit );

--- a/src/sass/home/_dta-gov-au.home.mid-top-content.scss
+++ b/src/sass/home/_dta-gov-au.home.mid-top-content.scss
@@ -13,6 +13,7 @@
   }
   .au-card-list {
     @include AU-card-cta-link($AU-color-foreground-text);
+    @include AU-card-colours;
   }
   .au-body {
     background-color: transparent;

--- a/templates/ds/ds-1col--node-blog-post-card.html.twig
+++ b/templates/ds/ds-1col--node-blog-post-card.html.twig
@@ -14,12 +14,4 @@
   */
 #}
 
-{%
-  set classes = ['au-card', 'au-card--shadow']
-%}
-
-
-<article{{ attributes.addClass( classes ) }}>
-  {{ ds_content }}
-  {{ title_suffix.contextual_links }}
-</article>
+{{ ds_content }}

--- a/templates/ds/ds-1col--node-news-item-card.html.twig
+++ b/templates/ds/ds-1col--node-news-item-card.html.twig
@@ -14,12 +14,4 @@
   */
 #}
 
-{%
-  set classes = ['au-card', 'au-card--shadow']
-%}
-
-
-<article{{ attributes.addClass( classes ) }}>
-  {{ ds_content }}
-  {{ title_suffix.contextual_links }}
-</article>
+{{ ds_content }}


### PR DESCRIPTION
This commit adjusts the card colours and hover states:
 - Adds a default background hover for cards if not using the card colour mixin (ie blog cards).
 - Adds focus states for default cards and coloured cards.
 - Removes extra stuff around blog and news item cards to accomodate the new whole-card link.