### PR TITLE
Swaps out `drupal_block` for `drupal_view`

### DIFF
--- a/templates/layout/page--book--digital-transformation-strategy.html.twig
+++ b/templates/layout/page--book--digital-transformation-strategy.html.twig
@@ -98,7 +98,7 @@
         <div class="row">
           <div id="card-content" class="au-body col-xs-12">
             {{ drupal_block('views_block__digital_transformation_strategy_themes_block_1') }}
-            {{ drupal_block('dtslandingpagecontent') }}
+            {{ drupal_view('landing_page_cards', 'block_4', '661') }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This replaces the view on the DTS landing page with a programmatic view using `drupal_view` (via Twig Tweak).