### PR TITLE
Alt text in event content type templates

### DIFF
--- a/templates/content/node--presentation--card.html.twig
+++ b/templates/content/node--presentation--card.html.twig
@@ -81,9 +81,9 @@
   <div class="au-card__image au-card__fullwidth">
     <figure>
       {% if type == 'Keynote' %}
-        <img src="{{ node.field_speaker.entity.field_index_image.entity.uri.value | image_style('index_image_small') }}" />
+        <img alt="{{ node.field_speaker.entity.field_index_image.alt }}" src="{{ node.field_speaker.entity.field_index_image.entity.uri.value | image_style('index_image_small') }}" />
       {% else %}
-        <img src="{{ node.field_presentation_type.entity.field_index_image.entity.uri.value | image_style('index_image_small') }}" />
+        <img alt="{{ node.field_presentation_type.entity.field_index_image.alt }}" src="{{ node.field_presentation_type.entity.field_index_image.entity.uri.value | image_style('index_image_small') }}" />
       {% endif %}
     </figure>
   </div>

--- a/templates/content/node--speaker-bio--card.html.twig
+++ b/templates/content/node--speaker-bio--card.html.twig
@@ -77,7 +77,7 @@
   <a href="{{ url('<front>') }}" class="au-card au-card--shadow au-cta-link" hreflang="en">
 {% endif %}
   <div class="au-card__image au-card__fullwidth">
-    <img src="{{ content.field_index_image['#items'].entity.uri.value | image_style('index_image_small') }}" />
+    <img alt="{{ content.field_index_image['#items'].alt }}" src="{{ content.field_index_image['#items'].entity.uri.value | image_style('index_image_small') }}" />
   </div>
   <h3 class="au-card__title">{{ label }}</h3>
   <div class="au-card__text">


### PR DESCRIPTION
This commit adds alt text into event content type templates. The perils of directly accessing fields!